### PR TITLE
Add a flag to specify 'additionalProperties' value on objects' schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ with the JSON Schema model.
 ```javascript
 var compile = require('protobuf-jsonschema');
 
-var all = compile('models.proto', true);
-var single = compile('models.proto', 'MyModel', true);
+var all = compile({ allow_additional_props: true }, 'models.proto');
+var single = compile({ allow_additional_props: true }, 'models.proto', 'MyModel');
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $ protobuf-jsonschema --help
     -h, --help             output usage information
     -V, --version          output the version number
     -f, --format [format]  output format: json or yaml [json]
+    -a, --allow            true if validator should allow additional properties, false if not. This will apply to all objects in the schema.
 ```
 
 In node, `protobuf-jsonschema` exports a single function that returns an object
@@ -30,8 +31,8 @@ with the JSON Schema model.
 ```javascript
 var compile = require('protobuf-jsonschema');
 
-var all = compile('models.proto');
-var single = compile('models.proto', 'MyModel');
+var all = compile('models.proto', true);
+var single = compile('models.proto', 'MyModel', true);
 ```
 
 ## License

--- a/cli.js
+++ b/cli.js
@@ -8,9 +8,11 @@ commander
   .version(require('./package.json').version)
   .arguments('<file> [model]')
   .option('-f, --format [format]', 'output format: json or yaml [json]', 'json')
+  .option('-a, --allow [allow]', 'allow additional properties: true or false', 'true')
   .action(function(file, model) {
     var format = commander.format || 'json';
-    var result = compile(file, model);
+    var allow_additional_props = !(commander.allow == 'false');
+    var result = compile(file, null,allow_additional_props);
     
     if (format === 'json')
       process.stdout.write(JSON.stringify(result, false, 2) + '\n');

--- a/cli.js
+++ b/cli.js
@@ -11,8 +11,8 @@ commander
   .option('-a, --allow [allow]', 'allow additional properties: true or false', 'true')
   .action(function(file, model) {
     var format = commander.format || 'json';
-    var allow_additional_props = !(commander.allow == 'false');
-    var result = compile(file, null,allow_additional_props);
+    var opts = { allow_additional_props : !(commander.allow == 'false') };
+    var result = compile(opts, file, model);
     
     if (format === 'json')
       process.stdout.write(JSON.stringify(result, false, 2) + '\n');

--- a/index.js
+++ b/index.js
@@ -50,21 +50,21 @@ Compiler.prototype.visit = function(schema, prefix) {
  * compiles just that type and its dependencies. Otherwise,
  * compiles all types in the file.
  */
-Compiler.prototype.compile = function(type) {
+Compiler.prototype.compile = function(type, allow_additional_props) {
   this.root = {
     definitions: {},
     used: {}
   };
   
   if (type) {
-    this.resolve(type, '');
+    this.resolve(type, '', allow_additional_props);
   } else {
     this.schema.messages.forEach(function(message) {
-      this.resolve(message.id, '');
+      this.resolve(message.id, '', allow_additional_props);
     }, this);
     
     this.schema.enums.forEach(function(e) {
-      this.resolve(e.id, '');
+      this.resolve(e.id, '', allow_additional_props);
     }, this);
   }
   
@@ -76,7 +76,8 @@ Compiler.prototype.compile = function(type) {
  * Resolves a type name at the given path in the schema tree.
  * Returns a compiled JSON schema.
  */
-Compiler.prototype.resolve = function(type, from, base, key) {
+Compiler.prototype.resolve = function(type, from, allow_additional_props, base, key) {
+
   if (primitive[type])
     return primitive[type];
   
@@ -98,7 +99,7 @@ Compiler.prototype.resolve = function(type, from, base, key) {
     // Compile the message or enum
     var res;
     if (this.messages[id])
-      res = this.compileMessage(this.messages[id]);
+      res = this.compileMessage(this.messages[id],root,allow_additional_props);
   
     if (this.enums[id])
       res = this.compileEnum(this.enums[id]);
@@ -124,8 +125,8 @@ Compiler.prototype.resolve = function(type, from, base, key) {
 /**
  * Compiles and assigns a type
  */
-Compiler.prototype.build = function(type, from, base, key) {
-  var res = this.resolve(type, from, base, key);
+Compiler.prototype.build = function(type, from, allow_additional_props, base, key) {
+  var res = this.resolve(type, from, allow_additional_props, base, key);
   if (base)
     base[key] = res;
 };
@@ -146,11 +147,12 @@ Compiler.prototype.compileEnum = function(enumType, root) {
 /**
  * Compiles a protobuf message to JSON schema
  */
-Compiler.prototype.compileMessage = function(message, root) {
+Compiler.prototype.compileMessage = function(message, root, allow_additional_props) {
   var res = {
     title: message.name,
     type: 'object',
     properties: {},
+    additionalProperties: allow_additional_props,
     required: []
   };
   
@@ -164,17 +166,17 @@ Compiler.prototype.compileMessage = function(message, root) {
         additionalProperties: null
       };
       
-      this.build(field.map.to, message.id, f, 'additionalProperties');
+      this.build(field.map.to, message.id, allow_additional_props, f, 'additionalProperties');
     } else {      
       if (field.repeated) {
         var f = res.properties[field.name] = {
           type: 'array',
           items: null
         };
-        
-        this.build(field.type, message.id, f, 'items');
+       
+        this.build(field.type, message.id, allow_additional_props, f, 'items');
       } else {
-        this.build(field.type, message.id, res.properties, field.name);
+        this.build(field.type, message.id, allow_additional_props, res.properties, field.name);
       }
     }
     
@@ -188,7 +190,7 @@ Compiler.prototype.compileMessage = function(message, root) {
   return res;
 };
 
-module.exports = function(filename, model) {
+module.exports = function(filename, model,allow_additional_props) {
   var compiler = new Compiler(filename);
-  return compiler.compile(model);
+  return compiler.compile(model,allow_additional_props);
 };

--- a/index.js
+++ b/index.js
@@ -50,21 +50,21 @@ Compiler.prototype.visit = function(schema, prefix) {
  * compiles just that type and its dependencies. Otherwise,
  * compiles all types in the file.
  */
-Compiler.prototype.compile = function(type, allow_additional_props) {
+Compiler.prototype.compile = function(opts, type) {
   this.root = {
     definitions: {},
     used: {}
   };
   
   if (type) {
-    this.resolve(type, '', allow_additional_props);
+    this.resolve(opts, type, '');
   } else {
     this.schema.messages.forEach(function(message) {
-      this.resolve(message.id, '', allow_additional_props);
+      this.resolve(opts, message.id, '');
     }, this);
     
     this.schema.enums.forEach(function(e) {
-      this.resolve(e.id, '', allow_additional_props);
+      this.resolve(opts, e.id, '');
     }, this);
   }
   
@@ -76,7 +76,7 @@ Compiler.prototype.compile = function(type, allow_additional_props) {
  * Resolves a type name at the given path in the schema tree.
  * Returns a compiled JSON schema.
  */
-Compiler.prototype.resolve = function(type, from, allow_additional_props, base, key) {
+Compiler.prototype.resolve = function(opts, type, from, base, key) {
 
   if (primitive[type])
     return primitive[type];
@@ -99,7 +99,7 @@ Compiler.prototype.resolve = function(type, from, allow_additional_props, base, 
     // Compile the message or enum
     var res;
     if (this.messages[id])
-      res = this.compileMessage(this.messages[id],root,allow_additional_props);
+      res = this.compileMessage(opts, this.messages[id]);
   
     if (this.enums[id])
       res = this.compileEnum(this.enums[id]);
@@ -125,8 +125,8 @@ Compiler.prototype.resolve = function(type, from, allow_additional_props, base, 
 /**
  * Compiles and assigns a type
  */
-Compiler.prototype.build = function(type, from, allow_additional_props, base, key) {
-  var res = this.resolve(type, from, allow_additional_props, base, key);
+Compiler.prototype.build = function(opts, type, from, base, key) {
+  var res = this.resolve(opts, type, from, base, key);
   if (base)
     base[key] = res;
 };
@@ -147,12 +147,12 @@ Compiler.prototype.compileEnum = function(enumType, root) {
 /**
  * Compiles a protobuf message to JSON schema
  */
-Compiler.prototype.compileMessage = function(message, root, allow_additional_props) {
+Compiler.prototype.compileMessage = function(opts, message, root) {
   var res = {
     title: message.name,
     type: 'object',
     properties: {},
-    additionalProperties: allow_additional_props,
+    additionalProperties: opts.allow_additional_props,
     required: []
   };
   
@@ -166,7 +166,7 @@ Compiler.prototype.compileMessage = function(message, root, allow_additional_pro
         additionalProperties: null
       };
       
-      this.build(field.map.to, message.id, allow_additional_props, f, 'additionalProperties');
+      this.build(opts, field.map.to, message.id, f, 'additionalProperties');
     } else {      
       if (field.repeated) {
         var f = res.properties[field.name] = {
@@ -174,9 +174,9 @@ Compiler.prototype.compileMessage = function(message, root, allow_additional_pro
           items: null
         };
        
-        this.build(field.type, message.id, allow_additional_props, f, 'items');
+        this.build(opts, field.type, message.id, f, 'items');
       } else {
-        this.build(field.type, message.id, allow_additional_props, res.properties, field.name);
+        this.build(opts, field.type, message.id, res.properties, field.name);
       }
     }
     
@@ -190,7 +190,7 @@ Compiler.prototype.compileMessage = function(message, root, allow_additional_pro
   return res;
 };
 
-module.exports = function(filename, model,allow_additional_props) {
+module.exports = function(opts, filename, model) {
   var compiler = new Compiler(filename);
-  return compiler.compile(model,allow_additional_props);
+  return compiler.compile(opts, model);
 };


### PR DESCRIPTION
The JSON-Schema definition allows for a `additionalProperties` boolean field to be added to each object definition. It defaults to true but, when false, the validator using the schemas will complain about extraneous fields. 

My project currently needs this so I've tried to update the code to allow this. At the moment, I've added a flag that will apply to all protobuf messages.

If this PR is ok for you, could you issue a release of the package on the NPM repo ?

Thanks