### PR TITLE
Allow importing definitions from anywhere

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,18 +3,26 @@
 var commander = require('commander');
 var compile = require('./');
 var yaml = require('js-yaml');
+var path = require('path');
 
 commander
   .version(require('./package.json').version)
   .arguments('<file> [model]')
   .option('-f, --format [format]', 'output format: json or yaml [json]', 'json')
+  .option('-I, --import [dir]', 'directory to search for imports (repeatable)', collect, [])
   .action(function(file, model) {
     var format = commander.format || 'json';
-    var result = compile(file, model);
-    
+    var imports = [path.dirname(file)].concat(commander.import);
+    var result = compile(file, model, imports);
+
     if (format === 'json')
       process.stdout.write(JSON.stringify(result, false, 2) + '\n');
     else if (format === 'yaml')
       process.stdout.write(yaml.dump(result, { noRefs: true }));
   })
   .parse(process.argv);
+
+function collect(val, memo) {
+  memo.push(val);
+  return memo;
+}

--- a/index.js
+++ b/index.js
@@ -3,24 +3,48 @@ var primitive = require('./types');
 var fs = require('fs');
 var path = require('path');
 
-function Compiler(filename) {
+function Compiler(filename, importPaths) {
   this.messages = {};
   this.enums = {};
-  this.schema = this.open(filename);
+  this.schema = this.open(filename, importPaths);
 }
 
-Compiler.prototype.open = function(filename) {
+Compiler.prototype.open = function(filename, importPaths) {
   if (!/\.proto$/i.test(filename) && !fs.existsSync(filename)) {
     filename += '.proto';
   }
 
   var schema = parseSchema(fs.readFileSync(filename, 'utf-8'));
   this.visit(schema, schema.package || '');
-  
-  schema.imports.forEach(function(i) {
-    this.open(path.resolve(path.dirname(filename), i));
+  schema.imports.forEach(function(lib) {
+    var found = false;
+    for (var i=0, len=importPaths.length; i<len; i++) {
+      try {
+        try {
+          this.open(path.resolve(importPaths[i], lib), importPaths);
+          found = true;
+          break;
+        } catch (err) {
+          if (err.code === 'ENOENT') {
+            // Try with only the import filename
+            this.open(path.resolve(importPaths[i], path.basename(lib)), importPaths);
+            found = true;
+            continue;
+          }
+          throw(err);
+        }
+      } catch (err) {
+        if (err.code === 'ENOENT') {
+          continue;
+        }
+        throw(err);
+      }
+    }
+    if (!found) {
+      throw new Error(lib + ' could not be found in any of\n' + importPaths.map(function(p) { return '\t' + path.resolve(p, lib) }).join('\n'));
+    }
   }, this);
-  
+
   return schema;
 };
 
@@ -35,7 +59,7 @@ Compiler.prototype.visit = function(schema, prefix) {
       this.visit(e, e.id);
     }, this);
   }
-  
+
   if (schema.messages) {
     schema.messages.forEach(function(m) {
       m.id = prefix + (prefix ? '.' : '') + (m.id || m.name);
@@ -55,19 +79,19 @@ Compiler.prototype.compile = function(type) {
     definitions: {},
     used: {}
   };
-  
+
   if (type) {
     this.resolve(type, '');
   } else {
     this.schema.messages.forEach(function(message) {
       this.resolve(message.id, '');
     }, this);
-    
+
     this.schema.enums.forEach(function(e) {
       this.resolve(e.id, '');
     }, this);
   }
-  
+
   delete this.root.used;
   return this.root;
 };
@@ -79,45 +103,45 @@ Compiler.prototype.compile = function(type) {
 Compiler.prototype.resolve = function(type, from, base, key) {
   if (primitive[type])
     return primitive[type];
-  
+
   var lookup = from.split('.');
   for (var i = lookup.length; i >= 0; i--) {
     var id = lookup.slice(0, i).concat(type).join('.');
-  
+
     // If this type was used before, move it from inline to a reusable definition
     if (this.root.used[id] && !this.root.definitions[id]) {
       var k = this.root.used[id];
       this.root.definitions[id] = k[0][k[1]];
       k[0][k[1]] = { $ref: '#/definitions/' + id };
     }
-  
+
     // If already defined, reuse
     if (this.root.definitions[id])
       return { $ref: '#/definitions/' + id };
-  
+
     // Compile the message or enum
     var res;
     if (this.messages[id])
       res = this.compileMessage(this.messages[id]);
-  
+
     if (this.enums[id])
       res = this.compileEnum(this.enums[id]);
-  
+
     if (res) {
       // If used, or at the root level, make a definition
       if (this.root.used[id] || !base) {
         this.root.definitions[id] = res;
         res = { $ref: '#/definitions/' + id };
       }
-      
+
       // Mark as used
       if (base && !this.root.used[id])
         this.root.used[id] = [base, key];
-    
+
       return res;
     }
   }
-  
+
   throw new Error('Could not resolve ' + type);
 };
 
@@ -139,7 +163,7 @@ Compiler.prototype.compileEnum = function(enumType, root) {
     type: 'string',
     enum: Object.keys(enumType.values)
   };
-  
+
   return res;
 };
 
@@ -153,42 +177,42 @@ Compiler.prototype.compileMessage = function(message, root) {
     properties: {},
     required: []
   };
-  
+
   message.fields.forEach(function(field) {
     if (field.map) {
       if (field.map.from !== 'string')
         throw new Error('Can only use strings as map keys at ' + message.id + '.' + field.name);
-      
+
       var f = res.properties[field.name] = {
         type: 'object',
         additionalProperties: null
       };
-      
+
       this.build(field.map.to, message.id, f, 'additionalProperties');
-    } else {      
+    } else {
       if (field.repeated) {
         var f = res.properties[field.name] = {
           type: 'array',
           items: null
         };
-        
+
         this.build(field.type, message.id, f, 'items');
       } else {
         this.build(field.type, message.id, res.properties, field.name);
       }
     }
-    
+
     if (field.required)
       res.required.push(field.name);
   }, this);
-  
+
   if (res.required.length === 0)
     delete res.required;
-  
+
   return res;
 };
 
-module.exports = function(filename, model) {
-  var compiler = new Compiler(filename);
+module.exports = function(filename, model, importPaths) {
+  var compiler = new Compiler(filename, importPaths);
   return compiler.compile(model);
 };


### PR DESCRIPTION
You can now specify an option to search any location for imports. This is useful if your .proto
definitions use any third party types e.g. google/protobuf/timestamp.proto.

The -I, --import option can be specified multiple times: paths are searched in the order they are
specified. The search logic looks for definitions both with and without the prefix namespace. For
example, an import directive for google/protobuf/timestamp.proto would search for both
google/protobuf/timestamp.proto and just timestamp.proto in all the paths specified.