### PR TITLE
Allow proto import paths relative to the working directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,12 @@ Compiler.prototype.open = function(filename) {
   this.visit(schema, schema.package || '');
   
   schema.imports.forEach(function(i) {
-    this.open(path.resolve(path.dirname(filename), i));
+    try {
+        this.open(path.resolve(path.dirname(filename), i));
+    } catch (e) {
+        this.open(path.resolve(process.cwd(), i));
+    }
+
   }, this);
   
   return schema;


### PR DESCRIPTION
When trying to follow an import, and failing a with a path relative to the current file, attempt to resolve the path relative to the current working directory