### PR TITLE
binary should be converted to type string with content encoding base64

### DIFF
--- a/types.js
+++ b/types.js
@@ -4,6 +4,7 @@ const MIN_SAFE_INTEGER = -MAX_SAFE_INTEGER;
 module.exports = {
   bytes: {
     type: 'string'
+    contentEncoding: 'base64'
   },
   string: {
     type: 'string'


### PR DESCRIPTION
According to https://developers.google.com/protocol-buffers/docs/proto3#json `bytes` should be  base64 string: which translates to 
```
"type": "string"
"contentEncoding": "base64"
```